### PR TITLE
Add /icons prefix to all URLs

### DIFF
--- a/app/helpers/icons.py
+++ b/app/helpers/icons.py
@@ -2,7 +2,7 @@ def get_icon_set_template_url(base_url=''):
     """
     Generate and return a template URL to access icon_sets' metadata
     """
-    return f"{base_url}/{{icon_set_name}}"
+    return f"{base_url}/sets/{{icon_set_name}}"
 
 
 def get_icon_template_url(base_url='', with_color=True):
@@ -12,5 +12,5 @@ def get_icon_template_url(base_url='', with_color=True):
     color_part = ""
     if with_color:
         color_part = "-{r},{g},{b}"
-    return f"{get_icon_set_template_url(base_url)}/icon/{{icon_name}}" \
+    return f"{get_icon_set_template_url(base_url)}/icons/{{icon_name}}" \
            f"@{{icon_scale}}{color_part}.png"

--- a/app/routes.py
+++ b/app/routes.py
@@ -12,6 +12,8 @@ from app.helpers.check_functions import check_color_channels
 from app.helpers.check_functions import get_and_check_icon
 from app.helpers.check_functions import get_and_check_icon_set
 from app.helpers.route import prefix_route
+from app.icon import Icon
+from app.icon_set import IconSet
 from app.icon_set import get_all_icon_sets
 from app.settings import DEFAULT_COLOR
 from app.settings import ROUTE_PREFIX
@@ -23,37 +25,48 @@ logger = logging.getLogger(__name__)
 app.route = prefix_route(app.route, ROUTE_PREFIX)
 
 
+def make_api_compliant_response(response_object):
+    """
+    Making sure our responses are compliant with
+    https://github.com/geoadmin/doc-guidelines/blob/master/API.md
+    """
+    if isinstance(response_object, (Icon, IconSet)):
+        return make_response(jsonify({'success': True, **response_object.serialize()}))
+    if isinstance(response_object, list):
+        return make_response(jsonify({'success': True, "items": response_object}))
+    return make_response(jsonify({'success': True, **response_object}))
+
+
 @app.route('/checker')
 def checker_page():
     """
     Just a route for the health check.
     :return: OK with a 200 status code or raise error in case of unsupported version.
     """
-    return make_response(jsonify({'success': True, 'message': 'OK', 'version': APP_VERSION}))
+    return make_api_compliant_response({'message': 'OK', 'version': APP_VERSION})
 
 
 @app.route('/sets', methods=['GET'])
 def all_icon_sets():
-    return make_response(jsonify({"success": True, "items": get_all_icon_sets()}))
+    return make_api_compliant_response(get_all_icon_sets())
 
 
 @app.route('/sets/<string:icon_set_name>', methods=['GET'])
 def icon_set_metadata(icon_set_name):
-    icon_set = get_and_check_icon_set(icon_set_name)
-    return make_response(jsonify(icon_set))
+    return make_api_compliant_response(get_and_check_icon_set(icon_set_name))
 
 
 @app.route('/sets/<string:icon_set_name>/icons', methods=['GET'])
 def icons_from_icon_set(icon_set_name):
     icon_set = get_and_check_icon_set(icon_set_name)
-    return make_response(jsonify({"success": True, "items": icon_set.get_all_icons()}))
+    return make_api_compliant_response(icon_set.get_all_icons())
 
 
 @app.route('/sets/<string:icon_set_name>/icons/<string:icon_name>', methods=['GET'])
 def icon_metadata(icon_set_name, icon_name):
     icon_set = get_and_check_icon_set(icon_set_name)
     icon = get_and_check_icon(icon_set, icon_name)
-    return make_response(jsonify(icon))
+    return make_api_compliant_response(icon)
 
 
 @app.route('/sets/<string:icon_set_name>/icons/<string:icon_name>.png', methods=['GET'])

--- a/app/routes.py
+++ b/app/routes.py
@@ -32,39 +32,40 @@ def checker_page():
     return make_response(jsonify({'success': True, 'message': 'OK', 'version': APP_VERSION}))
 
 
-@app.route('', methods=['GET'])
-@app.route('/', methods=['GET'])
+@app.route('/sets', methods=['GET'])
 def all_icon_sets():
     return make_response(jsonify({"success": True, "items": get_all_icon_sets()}))
 
 
-@app.route('/<string:icon_set_name>', methods=['GET'])
+@app.route('/sets/<string:icon_set_name>', methods=['GET'])
 def icon_set_metadata(icon_set_name):
     icon_set = get_and_check_icon_set(icon_set_name)
     return make_response(jsonify(icon_set))
 
 
-@app.route('/<string:icon_set_name>/icons', methods=['GET'])
+@app.route('/sets/<string:icon_set_name>/icons', methods=['GET'])
 def icons_from_icon_set(icon_set_name):
     icon_set = get_and_check_icon_set(icon_set_name)
     return make_response(jsonify({"success": True, "items": icon_set.get_all_icons()}))
 
 
-@app.route('/<string:icon_set_name>/icon/<string:icon_name>', methods=['GET'])
+@app.route('/sets/<string:icon_set_name>/icons/<string:icon_name>', methods=['GET'])
 def icon_metadata(icon_set_name, icon_name):
     icon_set = get_and_check_icon_set(icon_set_name)
     icon = get_and_check_icon(icon_set, icon_name)
     return make_response(jsonify(icon))
 
 
-@app.route('/<string:icon_set_name>/icon/<string:icon_name>.png', methods=['GET'])
+@app.route('/sets/<string:icon_set_name>/icons/<string:icon_name>.png', methods=['GET'])
 @app.route(
-    '/<string:icon_set_name>/icon/<string:icon_name>-<int:red>,<int:green>,<int:blue>.png',
+    '/sets/<string:icon_set_name>/icons/<string:icon_name>-<int:red>,<int:green>,<int:blue>.png',
     methods=['GET']
 )
-@app.route('/<string:icon_set_name>/icon/<string:icon_name>@<string:scale>.png', methods=['GET'])
 @app.route(
-    '/<string:icon_set_name>/icon/<string:icon_name>@<string:scale>'
+    '/sets/<string:icon_set_name>/icons/<string:icon_name>@<string:scale>.png', methods=['GET']
+)
+@app.route(
+    '/sets/<string:icon_set_name>/icons/<string:icon_name>@<string:scale>'
     '-<int:red>,<int:green>,<int:blue>.png',
     methods=['GET']
 )

--- a/app/settings.py
+++ b/app/settings.py
@@ -1,6 +1,6 @@
 import os
 
-ROUTE_PREFIX = '/v4/iconsets'
+ROUTE_PREFIX = '/v4/icons'
 IMAGE_FOLDER = os.path.abspath(os.path.join(os.path.dirname(__file__), '../static/images/'))
 
 COLORABLE_ICON_SETS = ['default']

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -14,11 +14,9 @@ phases:
     runtime-versions:
       docker: 18
     commands:
-      - echo "Installing necessary dependencies"
-      - apt-get update && apt-get install -y docker-compose python3-pip python3-venv pass gnupg2
       - echo "Install aws cli v2 for docker login to ECR registry"
       - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-      - unzip awscliv2.zip
+      - unzip -q awscliv2.zip
       - ./aws/install
       - aws --version
       - echo "Login to AWS ECR docker registry"

--- a/openapi.yml
+++ b/openapi.yml
@@ -10,7 +10,7 @@ tags:
   - name: icon_sets
     description: All operations that will output icon sets
 paths:
-  /v4/iconsets/checker:
+  /v4/icons/checker:
     get:
       description: Route to check if the service is up.
       operationId: checker
@@ -42,7 +42,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
-  /v4/iconsets:
+  /v4/icons/sets:
     get:
       description: List all available icon sets.
       tags:
@@ -61,7 +61,7 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/icon_set'
-  '/v4/iconsets/{icon_set_name}':
+  '/v4/icons/sets/{icon_set_name}':
     get:
       description: Metadat of a single icon set
       tags:
@@ -90,7 +90,7 @@ paths:
                   name:
                     type: string
                     description: The name of this icon set
-  '/v4/iconsets/{icon_set_name}/icons':
+  '/v4/icons/sets/{icon_set_name}/icons':
     get:
       description: List all icons for a specific icon set
       tags:
@@ -116,7 +116,7 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/icon'
-  '/v4/iconsets/{icon_set_name}/icon/{icon_name}{icon_scale}-{red},{green},{blue}.png':
+  '/v4/icons/sets/{icon_set_name}/icons/{icon_name}{icon_scale}-{red},{green},{blue}.png':
     get:
       description: Colorized the specified symbol with the specified color.
       operationId: color
@@ -219,7 +219,7 @@ components:
       x-examples:
         icon_set:
           colorable: false
-          icons_url: 'https://service-icons.bgdi-dev.swisstopo.cloud/v4/iconsets/babs/icons'
+          icons_url: 'https://service-icons.bgdi-dev.swisstopo.cloud/v4/icons/sets/babs/icons'
           name: babs
       properties:
         colorable:
@@ -244,7 +244,7 @@ components:
         icon:
           icon_set: 'default'
           name: 'airfield'
-          url: 'https://service-icons.bgdi-dev.swisstopo.cloud/v4/iconsets/default/icon/airfield-255,0,0.png'
+          url: 'https://service-icons.bgdi-dev.swisstopo.cloud/v4/icons/sets/default/icons/airfield-255,0,0.png'
       properties:
         icon_set:
           type: string

--- a/tests/unit_tests/base_test.py
+++ b/tests/unit_tests/base_test.py
@@ -7,7 +7,8 @@ from app.settings import ROUTE_PREFIX
 def build_request_url_for_icon(
     icon_name="marker", scale='1x', red=255, green=0, blue=0, icon_category="default"
 ):
-    return f"{ROUTE_PREFIX}/{icon_category}/icon/{icon_name}@{scale}-{red},{green},{blue}.png"
+    return f"{ROUTE_PREFIX}/sets/{icon_category}" \
+           f"/icons/{icon_name}@{scale}-{red},{green},{blue}.png"
 
 
 class ServiceIconsUnitTests(unittest.TestCase):

--- a/tests/unit_tests/test_all_icons.py
+++ b/tests/unit_tests/test_all_icons.py
@@ -105,9 +105,9 @@ class AllIconsTest(ServiceIconsUnitTests):
 
     def test_all_icon_sets_endpoint(self):
         """
-        Checking that the endpoint /iconsets returns all available icon sets
+        Checking that the endpoint /sets returns all available icon sets
         """
-        response = self.app.get(f"{ROUTE_PREFIX}/", headers={"Origin": "map.geo.admin.ch"})
+        response = self.app.get(f"{ROUTE_PREFIX}/sets", headers={"Origin": "map.geo.admin.ch"})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content_type, "application/json")
         self.assertIn('success', response.json)
@@ -123,13 +123,13 @@ class AllIconsTest(ServiceIconsUnitTests):
 
     def test_all_icon_sets_metadata_endpoint(self):
         """
-        Checking that the endpoint /iconsets/{icon_set_name} returns all relevant information
+        Checking that the endpoint /sets/{icon_set_name} returns all relevant information
         about an icon set, and that the icon URL given provides all available icons
         """
         for icon_set_name in self.all_icon_sets:
             with self.subTest(icon_set_name=icon_set_name):
                 response = self.app.get(
-                    f"{ROUTE_PREFIX}/{icon_set_name}", headers={"Origin": "map.geo.admin.ch"}
+                    f"{ROUTE_PREFIX}/sets/{icon_set_name}", headers={"Origin": "map.geo.admin.ch"}
                 )
                 self.assertEqual(response.status_code, 200)
                 self.assertEqual(response.content_type, "application/json")
@@ -139,7 +139,9 @@ class AllIconsTest(ServiceIconsUnitTests):
                 self.assertIn('colorable', icon_set_metadata)
                 self.assertIn('icons_url', icon_set_metadata)
                 self.assertIsNotNone(icon_set_metadata['icons_url'])
-                self.assertTrue(icon_set_metadata['icons_url'].endswith(f"{icon_set_name}/icons"))
+                self.assertTrue(
+                    icon_set_metadata['icons_url'].endswith(f"sets/{icon_set_name}/icons")
+                )
                 icons_response = self.app.get(
                     icon_set_metadata['icons_url'], headers={"Origin": "map.geo.admin.ch"}
                 )
@@ -159,7 +161,7 @@ class AllIconsTest(ServiceIconsUnitTests):
         for icon_set_name in self.all_icon_sets:
             for icon_name in self.all_icon_sets[icon_set_name]:
                 with self.subTest(icon_set_name=icon_set_name, icon_name=icon_name):
-                    icon_metadata_url = f"{ROUTE_PREFIX}/{icon_set_name}/icon/{icon_name}"
+                    icon_metadata_url = f"{ROUTE_PREFIX}/sets/{icon_set_name}/icons/{icon_name}"
                     response = self.app.get(
                         icon_metadata_url, headers={"Origin": "map.geo.admin.ch"}
                     )
@@ -175,7 +177,7 @@ class AllIconsTest(ServiceIconsUnitTests):
                     self.assertTrue(json_response['template_url'].endswith(get_icon_template_url()))
                     self.assertIn('url', json_response)
                     self.assertIsNotNone(json_response['url'])
-                    icon_url_without_color = f"{ROUTE_PREFIX}/{icon_set_name}/icon"
+                    icon_url_without_color = f"{ROUTE_PREFIX}/sets/{icon_set_name}/icons"
                     if icon_set_name in COLORABLE_ICON_SETS:
                         self.assertTrue(
                             json_response['url'].
@@ -194,7 +196,7 @@ class AllIconsTest(ServiceIconsUnitTests):
         for icon_set_name in self.all_icon_sets:
             for icon_name in self.all_icon_sets[icon_set_name]:
                 with self.subTest(icon_set_name=icon_set_name, icon_name=icon_name):
-                    icon_url = f"{ROUTE_PREFIX}/{icon_set_name}/icon/{icon_name}.png"
+                    icon_url = f"{ROUTE_PREFIX}/sets/{icon_set_name}/icons/{icon_name}.png"
                     self.check_image(icon_name, icon_url)
 
     def test_all_icon_double_size(self):
@@ -204,7 +206,8 @@ class AllIconsTest(ServiceIconsUnitTests):
         for icon_set_name in self.all_icon_sets:
             for icon_name in self.all_icon_sets[icon_set_name]:
                 with self.subTest(icon_set_name=icon_set_name, icon_name=icon_name):
-                    double_size_icon_url = f"{ROUTE_PREFIX}/{icon_set_name}/icon/{icon_name}@2x.png"
+                    double_size_icon_url = f"{ROUTE_PREFIX}/sets/{icon_set_name}" \
+                                           f"/icons/{icon_name}@2x.png"
                     self.check_image(icon_name, double_size_icon_url, expected_size=96)
 
     def test_all_icon_half_size(self):
@@ -214,7 +217,8 @@ class AllIconsTest(ServiceIconsUnitTests):
         for icon_set_name in self.all_icon_sets:
             for icon_name in self.all_icon_sets[icon_set_name]:
                 with self.subTest(icon_set_name=icon_set_name, icon_name=icon_name):
-                    half_size_icon_url = f"{ROUTE_PREFIX}/{icon_set_name}/icon/{icon_name}@0.5x.png"
+                    half_size_icon_url = f"{ROUTE_PREFIX}/sets/{icon_set_name}" \
+                                         f"/icons/{icon_name}@0.5x.png"
                     self.check_image(icon_name, half_size_icon_url, expected_size=24)
 
     def test_all_icons_colorized(self):
@@ -226,7 +230,8 @@ class AllIconsTest(ServiceIconsUnitTests):
                 with self.subTest(icon_set_name=icon_set_name, icon_name=icon_name):
                     icon_set = get_icon_set(icon_set_name)
                     color_part = "-0,255,255" if icon_set.colorable else ""
-                    colored_url = f"{ROUTE_PREFIX}/{icon_set_name}/icon/{icon_name}{color_part}.png"
+                    colored_url = f"{ROUTE_PREFIX}/sets/{icon_set_name}" \
+                                  f"/icons/{icon_name}{color_part}.png"
                     self.check_image(
                         icon_name,
                         colored_url,
@@ -245,8 +250,8 @@ class AllIconsTest(ServiceIconsUnitTests):
                 with self.subTest(icon_set_name=icon_set_name, icon_name=icon_name):
                     icon_set = get_icon_set(icon_set_name)
                     color_part = "-0,0,255" if icon_set.colorable else ""
-                    colored_url = f"{ROUTE_PREFIX}/{icon_set_name}/icon/" \
-                                  f"{icon_name}@2x{color_part}.png"
+                    colored_url = f"{ROUTE_PREFIX}/sets/{icon_set_name}" \
+                                  f"/icons/{icon_name}@2x{color_part}.png"
                     self.check_image(
                         icon_name,
                         colored_url,
@@ -266,7 +271,7 @@ class AllIconsTest(ServiceIconsUnitTests):
                 with self.subTest(icon_set_name=icon_set_name, icon_name=icon_name):
                     icon_set = get_icon_set(icon_set_name)
                     color_part = "-0,255,0" if icon_set.colorable else ""
-                    colored_url = f"{ROUTE_PREFIX}/{icon_set_name}/icon/" \
+                    colored_url = f"{ROUTE_PREFIX}/sets/{icon_set_name}/icons/" \
                                   f"{icon_name}@.5x{color_part}.png"
                     self.check_image(
                         icon_name,

--- a/tests/unit_tests/test_endpoints_compliance.py
+++ b/tests/unit_tests/test_endpoints_compliance.py
@@ -1,0 +1,44 @@
+from app.settings import ROUTE_PREFIX
+from tests.unit_tests.base_test import ServiceIconsUnitTests
+
+
+def remove_prefix_slash(value):
+    if value.startswith('/'):
+        return value[len('/'):]
+    return value[:]
+
+
+class CheckerTests(ServiceIconsUnitTests):
+
+    def check_response_compliance(self, response, is_list_endpoint=False):
+        self.assertIsNotNone(response)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content_type, "application/json")
+        self.assertTrue('success' in response.json)
+        self.assertTrue(response.json['success'])
+        if is_list_endpoint:
+            self.assertTrue('items' in response.json)
+            self.assertIsNotNone(response.json['items'])
+
+    def launch_get_request(self, relative_endpoint):
+        return self.app.get(
+            f"{ROUTE_PREFIX}/{remove_prefix_slash(relative_endpoint)}",
+            headers={"Origin": "map.geo.admin.ch"}
+        )
+
+    def test_checker(self):
+        self.check_response_compliance(self.launch_get_request('/checker'))
+
+    def test_icon_sets_list(self):
+        self.check_response_compliance(self.launch_get_request('/sets'), is_list_endpoint=True)
+
+    def test_icon_set_metadata(self):
+        self.check_response_compliance(self.launch_get_request('/sets/default'))
+
+    def test_icons_list(self):
+        self.check_response_compliance(
+            self.launch_get_request('/sets/default/icons'), is_list_endpoint=True
+        )
+
+    def test_icon_metadata(self):
+        self.check_response_compliance(self.launch_get_request('/sets/default/icons/marker'))

--- a/tests/unit_tests/test_icons.py
+++ b/tests/unit_tests/test_icons.py
@@ -77,7 +77,7 @@ class IconsTests(ServiceIconsUnitTests):
 
     def test_icons_from_icon_set(self):
         response = self.app.get(
-            f"{ROUTE_PREFIX}/default/icons", headers={"Origin": "map.geo.admin.ch"}
+            f"{ROUTE_PREFIX}/sets/default/icons", headers={"Origin": "map.geo.admin.ch"}
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content_type, 'application/json')


### PR DESCRIPTION
So that the service follows our guidelines on how it should build its URLs. (service-icons => URLs start with /icons)