### PR TITLE
Moving all infra related config to infra (k8s)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -30,3 +30,4 @@ service_icons.py
 buildspec.yml
 .validaterc
 nose2-junit.xml
+.env.*

--- a/.env.local
+++ b/.env.local
@@ -1,1 +1,1 @@
-ALLOWED_DOMAINS=.*\.geo\.admin\.ch,.*\.bgdi\.ch,.*\.swisstopo\.cloud,localhost
+ALLOWED_DOMAINS=http[s]?://localhost

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,1 @@
+ALLOWED_DOMAINS=some_random_domain

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ format-lint: format lint
 
 .PHONY: test
 test: $(REQUIREMENTS)
-	$(NOSE) -c tests/unittest.cfg --verbose -s tests/
+	ENV_FILE=.env.test $(NOSE) -c tests/unittest.cfg --verbose -s tests/
 
 
 # Serve targets. Using these will run the application on your local machine. You can either serve with a wsgi front (like it would be within the container), or without.

--- a/app/settings.py
+++ b/app/settings.py
@@ -17,7 +17,5 @@ DEFAULT_COLOR = {"r": 255, "g": 0, "b": 0}
 TRAP_HTTP_EXCEPTIONS = True
 
 # Definition of the allowed domains for CORS implementation
-ALLOWED_DOMAINS_STRING = os.getenv(
-    'ALLOWED_DOMAINS', r'.*\.geo\.admin\.ch,.*\.bgdi\.ch,.*\.swisstopo\.cloud'
-)
+ALLOWED_DOMAINS_STRING = os.getenv('ALLOWED_DOMAINS', r'http[s]?://localhost')
 ALLOWED_DOMAINS = ALLOWED_DOMAINS_STRING.split(',')

--- a/tests/unit_tests/base_test.py
+++ b/tests/unit_tests/base_test.py
@@ -11,7 +11,16 @@ def build_request_url_for_icon(
            f"/icons/{icon_name}@{scale}-{red},{green},{blue}.png"
 
 
+ORIGIN_FOR_TESTING = "some_random_domain"
+
+
 class ServiceIconsUnitTests(unittest.TestCase):
+
+    def __init__(self, methodName: str):
+        super().__init__(methodName=methodName)
+        # check .env.test for Origin value
+        self.origin_for_testing = ORIGIN_FOR_TESTING
+        self.default_header = {"Origin": self.origin_for_testing}
 
     def setUp(self):
         self.app = app.test_client()
@@ -28,7 +37,8 @@ class ServiceIconsUnitTests(unittest.TestCase):
         green=0,
         blue=0,
         icon_category="default",
-        origin="map.geo.admin.ch"
+        # see .env.test
+        origin=ORIGIN_FOR_TESTING
     ):
         return self.app.get(
             build_request_url_for_icon(icon_name, scale, red, green, blue, icon_category),

--- a/tests/unit_tests/test_all_icons.py
+++ b/tests/unit_tests/test_all_icons.py
@@ -73,7 +73,7 @@ class AllIconsTest(ServiceIconsUnitTests):
         (it doesn't check if it is a zero value, because some icons have edges that are not of
         the primary color, resulting in an average color that can't be "pure")
         """
-        response = self.app.get(image_url, headers={"Origin": "map.geo.admin.ch"})
+        response = self.app.get(image_url, headers=self.default_header)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content_type, "image/png")
         # reading the icon image so that we can check its size in px and average color
@@ -107,7 +107,7 @@ class AllIconsTest(ServiceIconsUnitTests):
         """
         Checking that the endpoint /sets returns all available icon sets
         """
-        response = self.app.get(f"{ROUTE_PREFIX}/sets", headers={"Origin": "map.geo.admin.ch"})
+        response = self.app.get(f"{ROUTE_PREFIX}/sets", headers=self.default_header)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content_type, "application/json")
         self.assertIn('success', response.json)
@@ -129,7 +129,7 @@ class AllIconsTest(ServiceIconsUnitTests):
         for icon_set_name, icon_set in self.all_icon_sets.items():
             with self.subTest(icon_set_name=icon_set_name):
                 response = self.app.get(
-                    f"{ROUTE_PREFIX}/sets/{icon_set_name}", headers={"Origin": "map.geo.admin.ch"}
+                    f"{ROUTE_PREFIX}/sets/{icon_set_name}", headers=self.default_header
                 )
                 self.assertEqual(response.status_code, 200)
                 self.assertEqual(response.content_type, "application/json")
@@ -143,7 +143,7 @@ class AllIconsTest(ServiceIconsUnitTests):
                     icon_set_metadata['icons_url'].endswith(f"sets/{icon_set_name}/icons")
                 )
                 icons_response = self.app.get(
-                    icon_set_metadata['icons_url'], headers={"Origin": "map.geo.admin.ch"}
+                    icon_set_metadata['icons_url'], headers=self.default_header
                 )
                 self.assertEqual(icons_response.status_code, 200)
                 self.assertEqual(icons_response.content_type, "application/json")
@@ -160,9 +160,7 @@ class AllIconsTest(ServiceIconsUnitTests):
             for icon_name in icon_set:
                 with self.subTest(icon_set_name=icon_set_name, icon_name=icon_name):
                     icon_metadata_url = f"{ROUTE_PREFIX}/sets/{icon_set_name}/icons/{icon_name}"
-                    response = self.app.get(
-                        icon_metadata_url, headers={"Origin": "map.geo.admin.ch"}
-                    )
+                    response = self.app.get(icon_metadata_url, headers=self.default_header)
                     self.assertEqual(response.status_code, 200)
                     self.assertEqual(response.content_type, "application/json")
                     json_response = response.json

--- a/tests/unit_tests/test_checker.py
+++ b/tests/unit_tests/test_checker.py
@@ -6,7 +6,7 @@ from tests.unit_tests.base_test import ServiceIconsUnitTests
 class CheckerTests(ServiceIconsUnitTests):
 
     def test_checker(self):
-        response = self.app.get(f"{ROUTE_PREFIX}/checker", headers={"Origin": "map.geo.admin.ch"})
+        response = self.app.get(f"{ROUTE_PREFIX}/checker", headers=self.default_header)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content_type, "application/json")
         self.assertEqual(response.json, {"message": "OK", "success": True, "version": APP_VERSION})

--- a/tests/unit_tests/test_endpoints_compliance.py
+++ b/tests/unit_tests/test_endpoints_compliance.py
@@ -22,8 +22,7 @@ class CheckerTests(ServiceIconsUnitTests):
 
     def launch_get_request(self, relative_endpoint):
         return self.app.get(
-            f"{ROUTE_PREFIX}/{remove_prefix_slash(relative_endpoint)}",
-            headers={"Origin": "map.geo.admin.ch"}
+            f"{ROUTE_PREFIX}/{remove_prefix_slash(relative_endpoint)}", headers=self.default_header
         )
 
     def test_checker(self):

--- a/tests/unit_tests/test_icons.py
+++ b/tests/unit_tests/test_icons.py
@@ -55,7 +55,7 @@ class IconsTests(ServiceIconsUnitTests):
             request_url,
             data=json.dumps({"url": "https://test.bgdi.ch/test"}),
             content_type="application/json",
-            headers={"Origin": "map.geo.admin.ch"}
+            headers=self.default_header
         )
         self.assertEqual(
             response.status_code,
@@ -76,9 +76,7 @@ class IconsTests(ServiceIconsUnitTests):
         )
 
     def test_icons_from_icon_set(self):
-        response = self.app.get(
-            f"{ROUTE_PREFIX}/sets/default/icons", headers={"Origin": "map.geo.admin.ch"}
-        )
+        response = self.app.get(f"{ROUTE_PREFIX}/sets/default/icons", headers=self.default_header)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content_type, 'application/json')
         self.assertTrue('success' in response.json)


### PR DESCRIPTION
Only supporting settings that will work on local env
Ignoring file .env.* files so that it doesn't overwrite things we setup through k8s config files

see https://github.com/geoadmin/infra-kubernetes/pull/117 for infra config