### PR TITLE
BGDIINF_SB-2027: Added Cache-Control header and updated ALLOWED_DOMAIN default value

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -22,7 +22,7 @@ ignore-patterns=
 
 # Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
 # number of processors available to use.
-jobs=4
+jobs=1
 
 # Control the amount of potential inferred values when inferring a single
 # object. This can help the performance when dealing with large functions or
@@ -380,7 +380,7 @@ ignore-docstrings=yes
 ignore-imports=no
 
 # Minimum lines number of a similarity.
-min-similarity-lines=4
+min-similarity-lines=10
 
 
 [VARIABLES]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@
 
 - [Table of content](#table-of-content)
 - [Description](#description)
+- [Dependencies](#dependencies)
+- [Service API](#service-api)
   - [Staging Environments](#staging-environments)
+  - [checker GET](#checker-get)
+  - [color GET](#color-get)
 - [Versioning](#versioning)
 - [Local Development](#local-development)
   - [Make Dependencies](#make-dependencies)
@@ -18,6 +22,8 @@
   - [Test your work](#test-your-work)
 - [Docker](#docker)
 - [Deployment](#deployment)
+  - [Dev](#dev)
+  - [Int](#int)
   - [Deployment configuration](#deployment-configuration)
 
 ## Description
@@ -205,4 +211,7 @@ The service is configured by Environment Variable:
 
 | Env         | Default               | Description                |
 | ----------- | --------------------- | -------------------------- |
-| LOGGING_CFG | logging-cfg-local.yml | Logging configuration file |
+| LOGGING_CFG | `logging-cfg-local.yml` | Logging configuration file |
+| ALLOWED_DOMAINS | `.*` | Comma separated list of regex that are allowed as domain in Origin header |
+| CACHE_CONTROL | `public, max-age=86400` | Cache Control header value of the `GET /v4/icons/*` endpoints |
+| CACHE_CONTROL_4XX | `public, max-age=3600` | Cache Control header for 4XX responses |

--- a/app/settings.py
+++ b/app/settings.py
@@ -17,5 +17,7 @@ DEFAULT_COLOR = {"r": 255, "g": 0, "b": 0}
 TRAP_HTTP_EXCEPTIONS = True
 
 # Definition of the allowed domains for CORS implementation
-ALLOWED_DOMAINS_STRING = os.getenv('ALLOWED_DOMAINS', r'http[s]?://localhost')
-ALLOWED_DOMAINS = ALLOWED_DOMAINS_STRING.split(',')
+ALLOWED_DOMAINS = os.getenv('ALLOWED_DOMAINS', r'.*').split(',')
+
+CACHE_CONTROL = os.getenv('CACHE_CONTROL', 'public, max-age=86400')
+CACHE_CONTROL_4XX = os.getenv('CACHE_CONTROL_4XX', 'public, max-age=3600')

--- a/tests/unit_tests/base_test.py
+++ b/tests/unit_tests/base_test.py
@@ -45,8 +45,11 @@ class ServiceIconsUnitTests(unittest.TestCase):
             headers={"Origin": origin}
         )
 
-    def check_response_not_allowed(self, response, msg):
+    def check_response_not_allowed(self, response, msg, is_checker=False):
         self.assertEqual(response.status_code, 403, msg=msg)
+        if not is_checker:
+            self.assertIn('Cache-Control', response.headers)
+            self.assertIn('max-age=3600', response.headers['Cache-Control'])
         self.assertEqual(response.content_type, "application/json")
         self.assertEqual(
             response.json, {

--- a/tests/unit_tests/test_all_icons.py
+++ b/tests/unit_tests/test_all_icons.py
@@ -76,6 +76,8 @@ class AllIconsTest(ServiceIconsUnitTests):
         response = self.app.get(image_url, headers=self.default_header)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content_type, "image/png")
+        self.assertIn('Cache-Control', response.headers)
+        self.assertIn('max-age=', response.headers['Cache-Control'])
         # reading the icon image so that we can check its size in px and average color
         with Image.open(io.BytesIO(response.data)) as icon:
             width, height = icon.size
@@ -110,6 +112,8 @@ class AllIconsTest(ServiceIconsUnitTests):
         response = self.app.get(f"{ROUTE_PREFIX}/sets", headers=self.default_header)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content_type, "application/json")
+        self.assertIn('Cache-Control', response.headers)
+        self.assertIn('max-age=', response.headers['Cache-Control'])
         self.assertIn('success', response.json)
         self.assertTrue(response.json['items'])
         self.assertIn('items', response.json)
@@ -133,6 +137,8 @@ class AllIconsTest(ServiceIconsUnitTests):
                 )
                 self.assertEqual(response.status_code, 200)
                 self.assertEqual(response.content_type, "application/json")
+                self.assertIn('Cache-Control', response.headers)
+                self.assertIn('max-age=', response.headers['Cache-Control'])
                 icon_set_metadata = response.json
                 self.assertIn('name', icon_set_metadata)
                 self.assertEqual(icon_set_name, icon_set_metadata['name'])
@@ -163,6 +169,8 @@ class AllIconsTest(ServiceIconsUnitTests):
                     response = self.app.get(icon_metadata_url, headers=self.default_header)
                     self.assertEqual(response.status_code, 200)
                     self.assertEqual(response.content_type, "application/json")
+                    self.assertIn('Cache-Control', response.headers)
+                    self.assertIn('max-age=', response.headers['Cache-Control'])
                     json_response = response.json
                     self.assertIn('icon_set', json_response)
                     self.assertEqual(icon_set_name, json_response['icon_set'])

--- a/tests/unit_tests/test_checker.py
+++ b/tests/unit_tests/test_checker.py
@@ -9,10 +9,11 @@ class CheckerTests(ServiceIconsUnitTests):
         response = self.app.get(f"{ROUTE_PREFIX}/checker", headers=self.default_header)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content_type, "application/json")
+        self.assertNotIn('Cache-Control', response.headers)
         self.assertEqual(response.json, {"message": "OK", "success": True, "version": APP_VERSION})
 
     def test_checker_denied_without_origin(self):
         response = self.app.get(f"{ROUTE_PREFIX}/checker", headers={"Origin": ""})
         self.check_response_not_allowed(
-            response, msg="Should return HTTP 403 when origin is not authorized"
+            response, msg="Should return HTTP 403 when origin is not authorized", is_checker=True
         )

--- a/tests/unit_tests/test_endpoints_compliance.py
+++ b/tests/unit_tests/test_endpoints_compliance.py
@@ -10,10 +10,13 @@ def remove_prefix_slash(value):
 
 class CheckerTests(ServiceIconsUnitTests):
 
-    def check_response_compliance(self, response, is_list_endpoint=False):
+    def check_response_compliance(self, response, is_list_endpoint=False, have_cache_control=True):
         self.assertIsNotNone(response)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content_type, "application/json")
+        if have_cache_control:
+            self.assertIn('Cache-Control', response.headers)
+            self.assertIn('max-age=', response.headers['Cache-Control'])
         self.assertTrue('success' in response.json)
         self.assertTrue(response.json['success'])
         if is_list_endpoint:
@@ -26,7 +29,9 @@ class CheckerTests(ServiceIconsUnitTests):
         )
 
     def test_checker(self):
-        self.check_response_compliance(self.launch_get_request('/checker'))
+        self.check_response_compliance(
+            self.launch_get_request('/checker'), have_cache_control=False
+        )
 
     def test_icon_sets_list(self):
         self.check_response_compliance(self.launch_get_request('/sets'), is_list_endpoint=True)

--- a/tests/unit_tests/test_icons.py
+++ b/tests/unit_tests/test_icons.py
@@ -12,6 +12,8 @@ class IconsTests(ServiceIconsUnitTests):
         self.assertEqual(
             response.status_code, 400, "Should return a HTTP 400 when a RGB value is out of range"
         )
+        self.assertIn('Cache-Control', response.headers)
+        self.assertIn('max-age=3600', response.headers['Cache-Control'])
         self.assertEqual(response.content_type, "application/json")
         self.assertEqual(
             response.json,
@@ -30,6 +32,8 @@ class IconsTests(ServiceIconsUnitTests):
         self.assertEqual(
             response.status_code, 400, msg="Should return a HTTP 400 when file not found"
         )
+        self.assertIn('Cache-Control', response.headers)
+        self.assertIn('max-age=3600', response.headers['Cache-Control'])
         self.assertEqual(response.content_type, "application/json")
         self.assertEqual(
             response.json, {
@@ -79,6 +83,8 @@ class IconsTests(ServiceIconsUnitTests):
         response = self.app.get(f"{ROUTE_PREFIX}/sets/default/icons", headers=self.default_header)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content_type, 'application/json')
+        self.assertIn('Cache-Control', response.headers)
+        self.assertIn('max-age=', response.headers['Cache-Control'])
         self.assertTrue('success' in response.json)
         self.assertTrue(response.json['success'])
         self.assertTrue('items' in response.json)

--- a/wsgi.py
+++ b/wsgi.py
@@ -32,7 +32,7 @@ if __name__ == '__main__':
     options = {
         'bind': '%s:%s' % ('0.0.0.0', HTTP_PORT),
         'worker_class': 'gevent',
-        'workers': 2,  # scaling horizontaly is left to Kubernetes
+        'workers': 2,  # scaling horizontally is left to Kubernetes
         'timeout': 60,
         'logconfig_dict': get_logging_cfg()
     }


### PR DESCRIPTION
Sets the Cache-Control header to GET requests, except for /checker which
is not required.

Also changed the ALLOWED_DOMAIN default value to be consistent with
other services.