### PR TITLE
BGDIINF_SB-2420: Fixed browser origin validation

### DIFF
--- a/tests/unit_tests/test_all_icons.py
+++ b/tests/unit_tests/test_all_icons.py
@@ -108,6 +108,32 @@ class AllIconsTest(ServiceIconsUnitTests):
                         blue, average_color[2], delta=acceptable_color_delta, msg=error_message
                     )
 
+    def test_icon_set_origin_validation(self):
+        url = url_for('all_icon_sets')
+        response = self.app.get(url, headers={'Sec-Fetch-Site': 'same-origin'})
+        self.assertEqual(response.status_code, 200)
+        response = self.app.get(url, headers={'Origin': self.origin_for_testing})
+        self.assertEqual(response.status_code, 200)
+        response = self.app.get(url, headers={'Referer': self.origin_for_testing})
+        self.assertEqual(response.status_code, 200)
+
+        response = self.app.get(url, headers={'Origin': 'dummy'})
+        self.assertEqual(response.status_code, 403)
+        response = self.app.get(url, headers={'Referer': 'dummy'})
+        self.assertEqual(response.status_code, 403)
+        esponse = self.app.get(url, headers={'Origin': ''})
+        self.assertEqual(response.status_code, 403)
+        response = self.app.get(url, headers={'Referer': ''})
+        self.assertEqual(response.status_code, 403)
+        response = self.app.get(url, headers={'Sec-Fetch-Site': 'cross-site'})
+        self.assertEqual(response.status_code, 403)
+        response = self.app.get(url, headers={'Sec-Fetch-Site': 'none'})
+        self.assertEqual(response.status_code, 403)
+        response = self.app.get(url, headers={'Sec-Fetch-Site': ''})
+        self.assertEqual(response.status_code, 403)
+        response = self.app.get(url)
+        self.assertEqual(response.status_code, 403)
+
     def test_all_icon_sets_endpoint(self):
         """
         Checking that the endpoint /sets returns all available icon sets


### PR DESCRIPTION
The browser doesn't add the `Origin` header when the request is made from the
same origin. However it does always send the `Sec-Fetch-Site` header telling
if the request is from the same origin, cross origin or from user.
See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Site.
Unfortunately this `Sec-Fetch-Site` header is not supported by Safari !
Moreover we cannot hack the web application to always set the `Origin` header as
most browsers don't allow it.

So we need to check 2 headers: `Sec-Fetch-Site` and `Origin` with a fallback to the
Referer for Safari.

Also to have the correct CORS header in case of same origin we need to add the
correct allowed origin in CORS header which is the same as the request. In case
of cross-site then we use the Origin header as allowed origin in CORS.