### PR TITLE
BGDIINF_SB-2420: Origin validation fixes - #patch

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,1 +1,1 @@
-ALLOWED_DOMAINS=some_random_domain,http://localhost
+ALLOWED_DOMAINS=some_random_domain,.*\.geo\.admin\.ch,http://localhost

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -75,18 +75,26 @@ def validate_origin():
     origin = request.headers.get('Origin', None)
     referrer = request.headers.get('Referer', None)
 
-    if origin is None and referrer is None and sec_fetch_site is None:
-        logger.error('Referer and/or Origin and/or Sec-Fetch-Site headers not set')
-        abort(403, 'Not allowed')
-    if origin is not None and not is_domain_allowed(origin):
-        logger.error('Origin=%s is not allowed', origin)
-        abort(403, 'Not allowed')
-    if referrer is not None and not is_domain_allowed(referrer):
-        logger.error('Referer=%s is not allowed', referrer)
-        abort(403, 'Not allowed')
-    if sec_fetch_site is not None and sec_fetch_site != 'same-origin':
+    if origin is not None:
+        if is_domain_allowed(origin):
+            return
+        logger.error('Origin=%s does not match %s', origin, ALLOWED_DOMAINS_PATTERN)
+        abort(403, 'Permission denied')
+
+    if sec_fetch_site is not None:
+        if sec_fetch_site in ['same-origin', 'same-site']:
+            return
         logger.error('Sec-Fetch-Site=%s is not allowed', sec_fetch_site)
-        abort(403, 'Not allowed')
+        abort(403, 'Permission denied')
+
+    if referrer is not None:
+        if is_domain_allowed(referrer):
+            return
+        logger.error('Referer=%s does not match %s', referrer, ALLOWED_DOMAINS_PATTERN)
+        abort(403, 'Permission denied')
+
+    logger.error('Referer and/or Origin and/or Sec-Fetch-Site headers not set')
+    abort(403, 'Permission denied')
 
 
 @app.after_request

--- a/tests/unit_tests/base_test.py
+++ b/tests/unit_tests/base_test.py
@@ -80,7 +80,7 @@ class ServiceIconsUnitTests(unittest.TestCase):
         self.assertEqual(
             response.json, {
                 "error": {
-                    "code": 403, "message": "Not allowed"
+                    "code": 403, "message": "Permission denied"
                 }, "success": False
             }
         )


### PR DESCRIPTION
In the case where the request is done from a subdomain the Origin header and
the Sec-Fetch-Site headers were set. The later was however not set to
'same-origin' but 'same-site' because the origin is not equal but from a subdomain.

Due to this the validation failed because we only allowed Sec-Fetch-Site==same-origin.
This would also have been an issue if we would allow a cross site origin in
the allowed domain, in this case the Sec-Fetch-Site would be 'cross-site'.

So changed the validation logic to be clearer and correct. The validation is
done only on the Origin header with a first fallback to Sec-Fetch-Site if Origin
is not available and a last fallback to Referer header if the previous are
not available.