### PR TITLE
Remove Y anchor value for the time/cross icon 

### DIFF
--- a/app/icon.py
+++ b/app/icon.py
@@ -17,6 +17,7 @@ DEFAULT_ICON_ANCHOR = [24/48, 24/48]
 ICON_ANCHORS = {
     '001-marker': [24/48, 42/48],
     '007-marker-stroked': [24/48, 42/48],
+    '011-cross': [24/48, 0],
 }
 # yapf: enable
 

--- a/tests/unit_tests/test_all_icons.py
+++ b/tests/unit_tests/test_all_icons.py
@@ -278,7 +278,7 @@ class AllIconsTest(ServiceIconsUnitTests):
                         self.assertIsInstance(
                             fraction, (int, float), msg='"anchor" fraction should be int or float'
                         )
-                        self.assertTrue(fraction > 0, msg='"anchor" fraction should be > 0')
+                        self.assertTrue(fraction >= 0, msg='"anchor" fraction should be >= 0')
 
     def test_all_icon_basic_image(self):
         """


### PR DESCRIPTION
This way the icon will be placed on top of the given coordinate, which makes more sense with this icon.

Current result : 
<img width="75" alt="image" src="https://user-images.githubusercontent.com/11540521/186107881-66183e5c-d993-4e22-a70b-2433190b9436.png">
The goal is to have the joint of the X on top of the point