### PR TITLE
BGDIINF_SB-2650: Added Env Variables for workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,3 +172,5 @@ The service is configured by Environment Variable:
 | FORWARDED_PROTO_HEADER_NAME | `X-Forwarded-Proto` | Sets gunicorn `secure_scheme_headers` parameter to `{${FORWARDED_PROTO_HEADER_NAME}: 'https'}`. This settings is required in order to generate correct URLs in the service responses. See [Gunicorn Doc](https://docs.gunicorn.org/en/stable/settings.html#secure-scheme-headers). |
 | SCRIPT_NAME | `''` | If the service is behind a reverse proxy and not served at the root, the route prefix must be set in `SCRIPT_NAME`. |
 | WSGI_TIMEOUT | `5` | WSGI timeout. |
+| GUNICORN_TMPFS_DIR | `None` |The working directory for the gunicorn workers. |
+| WSGI_WORKERS | `2` | The number of workers per CPU. | 

--- a/wsgi.py
+++ b/wsgi.py
@@ -32,7 +32,9 @@ if __name__ == '__main__':
     options = {
         'bind': f"0.0.0.0:{HTTP_PORT}",
         'worker_class': 'gevent',
-        'workers': 2,  # scaling horizontally is left to Kubernetes
+        'worker_tmp_dir': os.getenv("GUNICORN_TMPFS_DIR", None),
+        'workers': int(os.getenv('WSGI_WORKERS',
+                                 '2')),  # scaling horizontally is left to Kubernetes
         'timeout': int(os.getenv('WSGI_TIMEOUT', '5')),
         'logconfig_dict': get_logging_cfg(),
         'forwarded_allow_ips': os.getenv('FORWARED_ALLOW_IPS', '*'),


### PR DESCRIPTION
Issue :
The number of workers couldn't be set by an environment variable, and the working directory was the default directory, which leads to disk reading, with poorer performances than a tmpfs.

Fix :
We created two environment variables, to allow kubernetes to set those at will, which will allow us to have a tmpfs as a working directory, and to change the number of workers at will to see if performances improve.