### PR TITLE
BGDIINF_SB-3115: Apparently IOS 16 has a bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,6 @@ help:
 	@echo "Possible targets:"
 	@echo -e " \033[1mSetup TARGETS\033[0m "
 	@echo "- setup              Create the python virtual environment and activate it"
-	@echo "- dev                Create the python virtual environment with developper tools and activate it"
 	@echo "- ci                 Create the python virtual environment and install requirements based on the Pipfile.lock"
 	@echo -e " \033[1mFORMATING, LINTING AND TESTING TOOLS TARGETS\033[0m "
 	@echo "- format             Format the python source code"
@@ -84,15 +83,9 @@ help:
 
 # Build targets. Calling setup is all that is needed for the local files to be installed as needed.
 
-.PHONY: dev
-dev:
-	pipenv install --dev
-	pipenv shell
-
-
 .PHONY: setup
 setup:
-	pipenv install
+	pipenv install --dev
 	pipenv shell
 
 


### PR DESCRIPTION
and set Sec-Fetch-Site=cross-site even if the

request is originated (same origin and/or referrer) from the same site ! Therefore to avoid

issue on IOS we first checks the referrer before checking Sec-Fetch-Site even if this not

correct.